### PR TITLE
Add RPG IV to Free Format and CL Prompter extensions by Bob Cozzi

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
         "IBM.ibmidebug",
         "IBM.vscode-ibmi-projectexplorer",
         "IBM.vscode-sourceorbit",
-        "IBM.vscode-ibmi-testing"
+        "IBM.vscode-ibmi-testing",
+        "CozziResearch.rpgiv2free",
+        "CozziResearch.clprompter"
     ]
 }

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,8 @@ This extension pack includes a set of extensions for IBM i development in Visual
 * [IBM i Project Explorer](https://marketplace.visualstudio.com/items?itemName=IBM.vscode-ibmi-projectexplorer)
 * [Source Orbit](https://marketplace.visualstudio.com/items?itemName=IBM.vscode-sourceorbit)
 * [IBM i Testing](https://marketplace.visualstudio.com/items?itemName=IBM.vscode-ibmi-testing)
+* [RPG IV to Free Format](https://marketplace.visualstudio.com/items?itemName=CozziResearch.rpgiv2free) - Convert RPG IV fixed-format code to free-format
+* [CL Prompter and Formatter](https://marketplace.visualstudio.com/items?itemName=CozziResearch.clprompter) - IBM i CL command prompting and formatting
 
 ### Niceties
 


### PR DESCRIPTION
This PR adds two IBM i development extensions by Bob Cozzi (CozziResearch) to the pack:

- **[RPG IV to Free Format](https://marketplace.visualstudio.com/items?itemName=CozziResearch.rpgiv2free)** (`CozziResearch.rpgiv2free`) — Converts RPG IV fixed-format statements to free-format RPG IV code. Includes smart tab/enter key support for fixed-format editing.

- **[CL Prompter and Formatter](https://marketplace.visualstudio.com/items?itemName=CozziResearch.clprompter)** (`CozziResearch.clprompter`) — Brings the familiar IBM i F4 CL command prompting experience and professional CL code formatting directly into VS Code.

Both extensions are natural companions to the existing IBM i tools in this pack and are widely used by IBM i RPG and CL developers.