### PR TITLE
Remove Source Orbit as it is deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "ibm-i-development-pack",
     "displayName": "IBM i Development Pack",
     "description": "Base extensions used for IBM i development in VS Code.",
-    "version": "0.3.4",
+    "version": "0.3.5",
 	"license": "MIT",
     "engines": {
         "vscode": "^1.59.0"
@@ -47,7 +47,6 @@
         "IBM.vscode-clle",
         "IBM.ibmidebug",
         "IBM.vscode-ibmi-projectexplorer",
-        "IBM.vscode-sourceorbit",
         "IBM.vscode-ibmi-testing"
     ]
 }

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,6 @@ This extension pack includes a set of extensions for IBM i development in Visual
 * [Db2 for IBM i](https://marketplace.visualstudio.com/items?itemName=HalcyonTechLtd.vscode-db2i)
 * [IBM i Renderer](https://marketplace.visualstudio.com/items?itemName=HalcyonTechLtd.vscode-displayfile)
 * [IBM i Project Explorer](https://marketplace.visualstudio.com/items?itemName=IBM.vscode-ibmi-projectexplorer)
-* [Source Orbit](https://marketplace.visualstudio.com/items?itemName=IBM.vscode-sourceorbit)
 * [IBM i Testing](https://marketplace.visualstudio.com/items?itemName=IBM.vscode-ibmi-testing)
 * [IBM i FileSystem](https://marketplace.visualstudio.com/items?itemName=HalcyonTechLtd.vscode-ibmi-fs)
 


### PR DESCRIPTION
Fixes #22

Source Orbit as deprecated so removing from the dev pack.