### PR TITLE
Add RPGIV2FREE and CL Prompter extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "IBM i Development Pack",
     "description": "Base extensions used for IBM i development in VS Code.",
     "version": "0.3.5",
-	"license": "MIT",
+    "license": "MIT",
     "engines": {
         "vscode": "^1.59.0"
     },
@@ -47,6 +47,8 @@
         "IBM.vscode-clle",
         "IBM.ibmidebug",
         "IBM.vscode-ibmi-projectexplorer",
-        "IBM.vscode-ibmi-testing"
+        "IBM.vscode-ibmi-testing",
+        "CozziResearch.rpgiv2free",
+        "CozziResearch.clprompter"
     ]
 }

--- a/readme.md
+++ b/readme.md
@@ -15,8 +15,12 @@ This extension pack includes a set of extensions for IBM i development in Visual
 * [IBM i Project Explorer](https://marketplace.visualstudio.com/items?itemName=IBM.vscode-ibmi-projectexplorer)
 * [IBM i Testing](https://marketplace.visualstudio.com/items?itemName=IBM.vscode-ibmi-testing)
 * [IBM i FileSystem](https://marketplace.visualstudio.com/items?itemName=HalcyonTechLtd.vscode-ibmi-fs)
-* [RPGIV2FREE](https://marketplace.visualstudio.com/items?itemName=CozziResearch.rpgiv2free) ([Open VSX](https://open-vsx.org/extension/CozziResearch/rpgiv2free))
-* [CL Prompter](https://marketplace.visualstudio.com/items?itemName=CozziResearch.clprompter) ([Open VSX](https://open-vsx.org/extension/CozziResearch/clprompter))
+* RPGIV2FREE
+  * [Get from Marketplace](https://marketplace.visualstudio.com/items?itemName=CozziResearch.rpgiv2free)
+  * [Get from Open VSX](https://open-vsx.org/extension/CozziResearch/rpgiv2free)
+* CL Prompter
+  * [Get from Marketplace](https://marketplace.visualstudio.com/items?itemName=CozziResearch.clprompter)
+  * [Get from Open VSX](https://open-vsx.org/extension/CozziResearch/clprompter)
 
 ### Niceties
 

--- a/readme.md
+++ b/readme.md
@@ -15,12 +15,8 @@ This extension pack includes a set of extensions for IBM i development in Visual
 * [IBM i Project Explorer](https://marketplace.visualstudio.com/items?itemName=IBM.vscode-ibmi-projectexplorer)
 * [IBM i Testing](https://marketplace.visualstudio.com/items?itemName=IBM.vscode-ibmi-testing)
 * [IBM i FileSystem](https://marketplace.visualstudio.com/items?itemName=HalcyonTechLtd.vscode-ibmi-fs)
-* RPGIV2FREE
-  * [Get from Marketplace](https://marketplace.visualstudio.com/items?itemName=CozziResearch.rpgiv2free)
-  * [Get from Open VSX](https://open-vsx.org/extension/CozziResearch/rpgiv2free)
-* CL Prompter
-  * [Get from Marketplace](https://marketplace.visualstudio.com/items?itemName=CozziResearch.clprompter)
-  * [Get from Open VSX](https://open-vsx.org/extension/CozziResearch/clprompter)
+* [RPGIV2FREE](https://marketplace.visualstudio.com/items?itemName=CozziResearch.rpgiv2free)
+* [CL Prompter](https://marketplace.visualstudio.com/items?itemName=CozziResearch.clprompter)
 
 ### Niceties
 

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,8 @@ This extension pack includes a set of extensions for IBM i development in Visual
 * [IBM i Project Explorer](https://marketplace.visualstudio.com/items?itemName=IBM.vscode-ibmi-projectexplorer)
 * [IBM i Testing](https://marketplace.visualstudio.com/items?itemName=IBM.vscode-ibmi-testing)
 * [IBM i FileSystem](https://marketplace.visualstudio.com/items?itemName=HalcyonTechLtd.vscode-ibmi-fs)
+* [RPGIV2FREE](https://marketplace.visualstudio.com/items?itemName=CozziResearch.rpgiv2free)
+* [CL Prompter](https://marketplace.visualstudio.com/items?itemName=CozziResearch.clprompter)
 
 ### Niceties
 

--- a/readme.md
+++ b/readme.md
@@ -15,8 +15,8 @@ This extension pack includes a set of extensions for IBM i development in Visual
 * [IBM i Project Explorer](https://marketplace.visualstudio.com/items?itemName=IBM.vscode-ibmi-projectexplorer)
 * [IBM i Testing](https://marketplace.visualstudio.com/items?itemName=IBM.vscode-ibmi-testing)
 * [IBM i FileSystem](https://marketplace.visualstudio.com/items?itemName=HalcyonTechLtd.vscode-ibmi-fs)
-* [RPGIV2FREE](https://marketplace.visualstudio.com/items?itemName=CozziResearch.rpgiv2free)
-* [CL Prompter](https://marketplace.visualstudio.com/items?itemName=CozziResearch.clprompter)
+* [RPGIV2FREE](https://marketplace.visualstudio.com/items?itemName=CozziResearch.rpgiv2free) ([Open VSX](https://open-vsx.org/extension/CozziResearch/rpgiv2free))
+* [CL Prompter](https://marketplace.visualstudio.com/items?itemName=CozziResearch.clprompter) ([Open VSX](https://open-vsx.org/extension/CozziResearch/clprompter))
 
 ### Niceties
 


### PR DESCRIPTION
Adds two IBM i language-specific extensions to the pack:

- **[RPGIV2FREE](https://marketplace.visualstudio.com/items?itemName=CozziResearch.rpgiv2free)** — Converts RPG IV fixed-format source to fully free-form RPG IV.
- **[CL Prompter](https://marketplace.visualstudio.com/items?itemName=CozziResearch.clprompter)** — CL command prompter and formatter for IBM i.

Both are added under the *IBM i and language specific* section in `readme.md` and included in `extensionPack` in `package.json`.